### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/custom_components/nexblue_hass/manifest.json
+++ b/custom_components/nexblue_hass/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/AndrewBarber/nexblue_hass/issues",
   "requirements": ["aiohttp>=3.0.0"],
-  "version": "0.3.1"
+  "version": "0.3.2"
 }


### PR DESCRIPTION
Bump `manifest.json` version to 0.3.2 in preparation for release.

**What's in this release:**
- Fix Hassfest CI failure (URL in translation string)
- Fix test runner CI failure (pycares/aiodns incompatibility via pytest-homeassistant-custom-component bump)
- Dependency bumps: pip, coverage, ruff, actions/checkout, actions/setup-python, ghaction-github-labeler, release-drafter