### PR TITLE
fix: sync VERSION in const.py to 0.3.2

### DIFF
--- a/custom_components/nexblue_hass/const.py
+++ b/custom_components/nexblue_hass/const.py
@@ -4,7 +4,7 @@
 NAME = "NexBlue EV Charger"
 DOMAIN = "nexblue_hass"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.3.1"
+VERSION = "0.3.2"
 
 ATTRIBUTION = "Data provided by NexBlue API"
 ISSUE_URL = "https://github.com/AndrewBarber/nexblue_hass/issues"


### PR DESCRIPTION
Fixes version mismatch: `const.py` still had `VERSION = "0.3.1"` after `manifest.json` was bumped to 0.3.2. This ensures the startup log message displays the correct version.