### PR TITLE
chore: clean up unused imports and dependencies

### DIFF
--- a/custom_components/nexblue_hass/__init__.py
+++ b/custom_components/nexblue_hass/__init__.py
@@ -10,7 +10,6 @@ from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.core_config import Config
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -25,11 +24,6 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 # This integration only uses config entry
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-
-
-async def async_setup(hass: HomeAssistant, config: Config):
-    """Set up this integration using YAML is not supported."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):

--- a/custom_components/nexblue_hass/api.py
+++ b/custom_components/nexblue_hass/api.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
 import aiohttp
-import async_timeout
 
 TIMEOUT = 10
 # API endpoints based on the OpenAPI specification
@@ -289,7 +288,7 @@ class NexBlueApiClient:
             headers = self._headers.copy() if self._access_token else HEADERS.copy()
 
         try:
-            async with async_timeout.timeout(TIMEOUT):
+            async with asyncio.timeout(TIMEOUT):
                 _LOGGER.debug(
                     "%s request to %s with data: %s", method.upper(), url, data
                 )

--- a/custom_components/nexblue_hass/manifest.json
+++ b/custom_components/nexblue_hass/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/AndrewBarber/nexblue_hass",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/AndrewBarber/nexblue_hass/issues",
-  "requirements": ["aiohttp>=3.0.0"],
+  "requirements": [],
   "version": "0.3.2"
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -80,15 +80,6 @@ async def test_setup_entry_exception(hass, error_on_get_data):
 
 
 @pytest.mark.asyncio
-async def test_async_setup(hass):
-    """Test async_setup function."""
-    from custom_components.nexblue_hass import async_setup
-
-    result = await async_setup(hass, {})
-    assert result is True
-
-
-@pytest.mark.asyncio
 async def test_async_unload_entry_empty_platforms(hass, bypass_get_data):
     """Test async_unload_entry with empty platforms list."""
     # Create a mock entry and coordinator with empty platforms


### PR DESCRIPTION
- Replace `async_timeout` with `asyncio.timeout` (built-in since Python 3.11, no external dep needed)
- Remove unused `Config` import and redundant `async_setup` from `__init__.py` (`CONFIG_SCHEMA` already handles YAML rejection)
- Remove `aiohttp` from `manifest.json` requirements — it is a HA core dependency and should not be declared by custom integrations