### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/custom_components/nexblue_hass/const.py
+++ b/custom_components/nexblue_hass/const.py
@@ -4,7 +4,7 @@
 NAME = "NexBlue EV Charger"
 DOMAIN = "nexblue_hass"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.3.2"
+VERSION = "0.3.3"
 
 ATTRIBUTION = "Data provided by NexBlue API"
 ISSUE_URL = "https://github.com/AndrewBarber/nexblue_hass/issues"

--- a/custom_components/nexblue_hass/manifest.json
+++ b/custom_components/nexblue_hass/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/AndrewBarber/nexblue_hass/issues",
   "requirements": [],
-  "version": "0.3.2"
+  "version": "0.3.3"
 }


### PR DESCRIPTION
Bump version to 0.3.3 in both `manifest.json` and `const.py`.

**What's in this release:**
- Replace `async_timeout` with `asyncio.timeout` (built-in since Python 3.11)
- Remove unused `Config` import and redundant `async_setup` from `__init__.py`
- Remove `aiohttp` from `manifest.json` requirements (HA core dependency)