### PR TITLE
fix: add write permissions to labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,9 @@ jobs:
   labeler:
     name: Labeler
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6.0.2


### PR DESCRIPTION
The labeler workflow was failing with `Resource not accessible by integration` because the `GITHUB_TOKEN` lacked write access to issues/labels.\n\nAdds `issues: write` and `pull-requests: write` permissions to the job so it can create and update labels from `.github/labels.yml`.