### PR TITLE
fix: add permissions to release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,9 @@ jobs:
   draft_release:
     name: Release Drafter
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - name: Run release-drafter
         uses: release-drafter/release-drafter@v7.2.1


### PR DESCRIPTION
Release drafter was failing with `Resource not accessible by integration` when trying to create/update draft releases.\n\nAdds `contents: write` (to create releases) and `pull-requests: read` (to read PR titles/labels for release notes) permissions to the job.