### PR TITLE
feat: add LED brightness sensor

### DIFF
--- a/custom_components/nexblue_hass/sensor.py
+++ b/custom_components/nexblue_hass/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    PERCENTAGE,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -164,6 +165,15 @@ SENSOR_TYPES: tuple[NexBlueSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:current-ac",
         value_fn=lambda data: data.get("status", {}).get("cable_current"),
+    ),
+    NexBlueSensorEntityDescription(
+        key="brightness",
+        name="LED Brightness",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:brightness-percent",
+        value_fn=lambda data: data.get("status", {}).get("brightness"),
     ),
 )
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -37,6 +37,7 @@ def mock_coordinator():
                     "voltage_list": [230.5, 231.2, 229.8],
                     "is_always_lock": 1,
                     "cable_current": 32,
+                    "brightness": 75,
                 },
                 "model": "EV Charger Model X",
                 "firmware_version": "1.0.0",
@@ -66,8 +67,8 @@ async def test_sensor_setup_entry(mock_coordinator, mock_config_entry):
     # Verify that sensors were added
     async_add_entities.assert_called_once()
     sensors = async_add_entities.call_args[0][0]
-    # Should create 11 sensors for 1 charger (added 2 cable lock sensors)
-    assert len(sensors) == 11
+    # Should create 12 sensors for 1 charger
+    assert len(sensors) == 12
     for sensor in sensors:
         assert isinstance(sensor, NexBlueSensor)
 
@@ -314,7 +315,7 @@ def test_charging_state_map():
 
 def test_sensor_types_count():
     """Test that SENSOR_TYPES contains expected number of sensors."""
-    assert len(SENSOR_TYPES) == 11  # Added 2 cable lock sensors
+    assert len(SENSOR_TYPES) == 12
 
 
 def test_sensor_types_structure():
@@ -405,6 +406,25 @@ def test_cable_current_sensor_not_plugged(mock_coordinator, mock_config_entry):
             break
 
     assert cable_current_sensor.native_value == 0
+
+
+def test_brightness_sensor(mock_coordinator, mock_config_entry):
+    """Test LED brightness sensor."""
+    sensor_type = next(s for s in SENSOR_TYPES if s.key == "brightness")
+    sensor = NexBlueSensor(mock_coordinator, mock_config_entry, "test123", sensor_type)
+
+    assert sensor.native_value == 75
+    assert sensor.native_unit_of_measurement == "%"
+    assert sensor.name == "NexBlue test123 LED Brightness"
+    assert sensor.unique_id == "test_test123_brightness"
+
+
+def test_brightness_sensor_missing(mock_coordinator, mock_config_entry):
+    """Test brightness sensor when data is missing."""
+    mock_coordinator.data["chargers"][0]["status"].pop("brightness")
+    sensor_type = next(s for s in SENSOR_TYPES if s.key == "brightness")
+    sensor = NexBlueSensor(mock_coordinator, mock_config_entry, "test123", sensor_type)
+    assert sensor.native_value is None
 
 
 def test_cable_lock_sensors_no_status(mock_coordinator, mock_config_entry):


### PR DESCRIPTION
## Changes

Adds a **LED Brightness** diagnostic sensor (0–100%) sourced from the `brightness` field already returned by the existing `/cmd/status` poll. No additional API calls required.

The API spec defines `brightness` as read-only with no corresponding write endpoint, so this is exposed as a sensor (not a number entity).

### Tests
- 2 new test cases: value read and missing-field handling
- `sensor.py` remains at 100% coverage