### PR TITLE
ci: remove ignore:brands from HACS action for default store submission

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,6 @@ jobs:
         uses: "hacs/action@22.5.0"
         with:
           category: "integration"
-          ignore: brands
 
   hassfest:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
The HACS default store submission requires the HACS action to run without any disabled checks. Removes `ignore: brands` so the action validates fully.