### PR TITLE
Prevent duplicate config entries

### DIFF
--- a/custom_components/nexblue_hass/config_flow.py
+++ b/custom_components/nexblue_hass/config_flow.py
@@ -31,6 +31,10 @@ class NexBlueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             username = user_input[CONF_USERNAME].strip()
             user_input = {**user_input, CONF_USERNAME: username}
+            if not username:
+                self._errors[CONF_USERNAME] = "username_required"
+                return await self._show_config_form(user_input)
+
             normalized_username = username.casefold()
 
             for entry in self._async_current_entries():

--- a/custom_components/nexblue_hass/config_flow.py
+++ b/custom_components/nexblue_hass/config_flow.py
@@ -28,11 +28,22 @@ class NexBlueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by the user."""
         self._errors = {}
 
-        # Uncomment the next 2 lines if only a single instance of the integration is allowed:
-        # if self._async_current_entries():
-        #     return self.async_abort(reason="single_instance_allowed")
-
         if user_input is not None:
+            username = user_input[CONF_USERNAME].strip()
+            user_input = {**user_input, CONF_USERNAME: username}
+            normalized_username = username.casefold()
+
+            for entry in self._async_current_entries():
+                configured_username = entry.data.get(CONF_USERNAME)
+                if (
+                    isinstance(configured_username, str)
+                    and configured_username.strip().casefold() == normalized_username
+                ):
+                    return self.async_abort(reason="already_configured")
+
+            await self.async_set_unique_id(normalized_username)
+            self._abort_if_unique_id_configured()
+
             valid = await self._test_credentials(
                 user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
             )

--- a/custom_components/nexblue_hass/translations/en.json
+++ b/custom_components/nexblue_hass/translations/en.json
@@ -16,6 +16,7 @@
       "unknown": "Unexpected error occurred. Please check the logs for more details."
     },
     "abort": {
+      "already_configured": "This NexBlue account is already configured.",
       "single_instance_allowed": "Only a single instance is allowed."
     }
   },

--- a/custom_components/nexblue_hass/translations/en.json
+++ b/custom_components/nexblue_hass/translations/en.json
@@ -13,6 +13,7 @@
     "error": {
       "auth": "Username/Password is wrong.",
       "cannot_connect": "Failed to connect to NexBlue API. Please check your internet connection and try again.",
+      "username_required": "Username is required.",
       "unknown": "Unexpected error occurred. Please check the logs for more details."
     },
     "abort": {

--- a/custom_components/nexblue_hass/translations/fr.json
+++ b/custom_components/nexblue_hass/translations/fr.json
@@ -11,7 +11,8 @@
       }
     },
     "error": {
-      "auth": "Identifiant ou mot de passe erroné."
+      "auth": "Identifiant ou mot de passe erroné.",
+      "username_required": "L'identifiant est obligatoire."
     },
     "abort": {
       "already_configured": "Ce compte NexBlue est déjà configuré.",

--- a/custom_components/nexblue_hass/translations/fr.json
+++ b/custom_components/nexblue_hass/translations/fr.json
@@ -14,6 +14,7 @@
       "auth": "Identifiant ou mot de passe erroné."
     },
     "abort": {
+      "already_configured": "Ce compte NexBlue est déjà configuré.",
       "single_instance_allowed": "Une seule instance est autorisée."
     }
   },

--- a/custom_components/nexblue_hass/translations/nb.json
+++ b/custom_components/nexblue_hass/translations/nb.json
@@ -11,10 +11,11 @@
       }
     },
     "error": {
-      "auth": "Brukernavn/Passord er feil."
+      "auth": "Brukernavn/Passord er feil.",
+      "username_required": "Brukernavn er påkrevd."
     },
     "abort": {
-      "already_configured": "Denne NexBlue-konto er allerede konfigurert.",
+      "already_configured": "Denne NexBlue-kontoen er allerede konfigurert.",
       "single_instance_allowed": "Denne integrasjonen kan kun konfigureres en gang."
     }
   },

--- a/custom_components/nexblue_hass/translations/nb.json
+++ b/custom_components/nexblue_hass/translations/nb.json
@@ -14,6 +14,7 @@
       "auth": "Brukernavn/Passord er feil."
     },
     "abort": {
+      "already_configured": "Denne NexBlue-konto er allerede konfigurert.",
       "single_instance_allowed": "Denne integrasjonen kan kun konfigureres en gang."
     }
   },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant import config_entries
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.nexblue_hass.config_flow import (
     NexBlueFlowHandler,
@@ -12,6 +13,7 @@ from custom_components.nexblue_hass.config_flow import (
 from custom_components.nexblue_hass.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
+    DOMAIN,
     PLATFORMS,
 )
 
@@ -66,7 +68,12 @@ async def test_async_step_user_valid_credentials(mock_hass):
     user_input = {CONF_USERNAME: "test@example.com", CONF_PASSWORD: "password123"}
 
     # Mock successful credential test
-    with patch.object(flow_handler, "_test_credentials", return_value=True):
+    with (
+        patch.object(flow_handler, "_async_current_entries", return_value=[]),
+        patch.object(flow_handler, "async_set_unique_id", new_callable=AsyncMock),
+        patch.object(flow_handler, "_abort_if_unique_id_configured"),
+        patch.object(flow_handler, "_test_credentials", return_value=True),
+    ):
         result = await flow_handler.async_step_user(user_input)
 
     assert result["type"] == "create_entry"
@@ -83,12 +90,108 @@ async def test_async_step_user_invalid_credentials(mock_hass):
     user_input = {CONF_USERNAME: "test@example.com", CONF_PASSWORD: "wrongpassword"}
 
     # Mock failed credential test
-    with patch.object(flow_handler, "_test_credentials", return_value=False):
+    with (
+        patch.object(flow_handler, "_async_current_entries", return_value=[]),
+        patch.object(flow_handler, "async_set_unique_id", new_callable=AsyncMock),
+        patch.object(flow_handler, "_abort_if_unique_id_configured"),
+        patch.object(flow_handler, "_test_credentials", return_value=False),
+    ):
         result = await flow_handler.async_step_user(user_input)
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "auth"
+
+
+@pytest.mark.asyncio
+async def test_async_step_user_normalizes_unique_id(mock_hass):
+    """Test async_step_user normalizes the duplicate-checking unique ID."""
+    flow_handler = NexBlueFlowHandler()
+    flow_handler.hass = mock_hass
+
+    user_input = {CONF_USERNAME: " Test@Example.COM ", CONF_PASSWORD: "password123"}
+
+    with (
+        patch.object(flow_handler, "_async_current_entries", return_value=[]),
+        patch.object(
+            flow_handler, "async_set_unique_id", new_callable=AsyncMock
+        ) as mock_set_unique_id,
+        patch.object(
+            flow_handler, "_abort_if_unique_id_configured"
+        ) as mock_abort_if_configured,
+        patch.object(
+            flow_handler, "_test_credentials", return_value=True
+        ) as mock_test_credentials,
+    ):
+        result = await flow_handler.async_step_user(user_input)
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "NexBlue (Test@Example.COM)"
+    assert result["data"][CONF_USERNAME] == "Test@Example.COM"
+    mock_set_unique_id.assert_awaited_once_with("test@example.com")
+    mock_abort_if_configured.assert_called_once()
+    mock_test_credentials.assert_awaited_once_with("Test@Example.COM", "password123")
+
+
+@pytest.mark.asyncio
+async def test_async_step_user_duplicate_username_aborts(
+    hass, enable_custom_integrations
+):
+    """Test duplicate NexBlue accounts are aborted before authentication."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="test@example.com",
+        data={CONF_USERNAME: "test@example.com", CONF_PASSWORD: "old_password"},
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+
+    with patch(
+        "custom_components.nexblue_hass.config_flow.NexBlueApiClient"
+    ) as mock_client_class:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: " Test@Example.COM ", CONF_PASSWORD: "password123"},
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    mock_client_class.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_step_user_duplicate_legacy_username_aborts(
+    hass, enable_custom_integrations
+):
+    """Test duplicate old entries without unique IDs are aborted by username."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "Test@Example.COM", CONF_PASSWORD: "old_password"},
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+
+    with patch(
+        "custom_components.nexblue_hass.config_flow.NexBlueApiClient"
+    ) as mock_client_class:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: " test@example.com ", CONF_PASSWORD: "password123"},
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    mock_client_class.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -106,7 +209,11 @@ async def test_async_step_user_credentials_with_error(mock_hass):
 
     with patch.object(
         flow_handler, "_test_credentials", side_effect=mock_test_credentials
-    ):
+    ), patch.object(
+        flow_handler, "_async_current_entries", return_value=[]
+    ), patch.object(
+        flow_handler, "async_set_unique_id", new_callable=AsyncMock
+    ), patch.object(flow_handler, "_abort_if_unique_id_configured"):
         result = await flow_handler.async_step_user(user_input)
 
     assert result["type"] == "form"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -104,6 +104,35 @@ async def test_async_step_user_invalid_credentials(mock_hass):
 
 
 @pytest.mark.asyncio
+async def test_async_step_user_empty_username_returns_form_error(mock_hass):
+    """Test async_step_user rejects usernames containing only whitespace."""
+    flow_handler = NexBlueFlowHandler()
+    flow_handler.hass = mock_hass
+
+    user_input = {CONF_USERNAME: "   ", CONF_PASSWORD: "password123"}
+
+    with (
+        patch.object(flow_handler, "_async_current_entries") as mock_current_entries,
+        patch.object(
+            flow_handler, "async_set_unique_id", new_callable=AsyncMock
+        ) as mock_set_unique_id,
+        patch.object(
+            flow_handler, "_abort_if_unique_id_configured"
+        ) as mock_abort_if_configured,
+        patch.object(flow_handler, "_test_credentials") as mock_test_credentials,
+    ):
+        result = await flow_handler.async_step_user(user_input)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"][CONF_USERNAME] == "username_required"
+    mock_current_entries.assert_not_called()
+    mock_set_unique_id.assert_not_called()
+    mock_abort_if_configured.assert_not_called()
+    mock_test_credentials.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_async_step_user_normalizes_unique_id(mock_hass):
     """Test async_step_user normalizes the duplicate-checking unique ID."""
     flow_handler = NexBlueFlowHandler()


### PR DESCRIPTION
The change prevents two config entries for the same NexBlue account by:

- checking existing entries with `self._async_current_entries()`
- comparing their stored `username`
- setting the normalized `username` as the config flow `unique_id`
- aborting with `already_configured` if it already exists

Quality scale rule: https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/unique-config-entry/